### PR TITLE
Add install-api CLI and SQL examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.egg-info/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Fetch a sample response from an API without writing any code:
 api-call "Cat Facts"
 ```
 
+## Beginner-friendly APIs
+
+List free APIs that work without keys:
+
+```bash
+api-beginner list --free --test-mode
+```
+
 ## Adding a new API
 
 API information lives in `apibotpi/apis.json`. Each entry looks like:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ If the console script is unavailable, you can run the module directly:
 python -m apibotpi.search --public
 ```
 
+Prefer no‑auth APIs and export results to CSV:
+
+```bash
+api-search --no-auth --format csv > apis.csv
+```
+
 Let the tool guide you interactively:
 
 ```bash
@@ -57,7 +63,13 @@ api-search --wizard
 Fetch a sample response from an API without writing any code:
 
 ```bash
-api-call "Cat Facts"
+api-call "Cat Facts" --param animal=cat
+```
+
+The call helper enforces HTTPS and retries with backoff. You can pass headers or custom timeouts, for example:
+
+```bash
+api-call "Cat Facts" --header "Accept: application/json" --timeout 10
 ```
 
 ## Beginner-friendly APIs
@@ -92,7 +104,7 @@ Instead of editing the registry by hand, install an OpenAPI or JSON spec directl
 install-api path-or-url-to-spec
 ```
 
-The command deduplicates entries based on name and host before appending them to `apibotpi/apis.json`.
+Records are validated and written atomically to avoid corrupting the registry. Entries are deduplicated by name and host.
 
 ## SQL snippets
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,94 @@
 # API-BOTPI
+
+This repository provides a minimal Python package skeleton.
+
+## Installation
+
+Run the installer script to set up a virtual environment and install the package:
+
+```bash
+./install.sh
+```
+
+After installation, activate the environment with:
+
+```bash
+source .venv/bin/activate
+```
+
+## Project layout
+
+```
+apibotpi/        # package code and API registry
+install.sh       # one-step installer
+pyproject.toml   # build configuration
+```
+
+## Searching APIs
+
+Use the helper to look up APIs by quota or whether they are in the public domain. Results include copy-and-paste URLs.
+
+List public domain APIs:
+
+```bash
+api-search --public
+```
+
+Search for APIs with "free" in their quota description:
+
+```bash
+api-search --quota free
+```
+
+If the console script is unavailable, you can run the module directly:
+
+```bash
+python -m apibotpi.search --public
+```
+
+Let the tool guide you interactively:
+
+```bash
+api-search --wizard
+```
+
+## Calling an API
+
+Fetch a sample response from an API without writing any code:
+
+```bash
+api-call "Cat Facts"
+```
+
+## Adding a new API
+
+API information lives in `apibotpi/apis.json`. Each entry looks like:
+
+```json
+{
+  "name": "Example API",
+  "description": "What it does",
+  "quota": "1000 calls/day",
+  "public_domain": true,
+  "url": "https://example.com/api"
+}
+```
+
+Append a new object to the JSON array and re-run `api-search` to confirm it appears. Copy and paste the example above to get started.
+
+## Installing API specs
+
+Instead of editing the registry by hand, install an OpenAPI or JSON spec directly:
+
+```bash
+install-api path-or-url-to-spec
+```
+
+The command deduplicates entries based on name and host before appending them to `apibotpi/apis.json`.
+
+## SQL snippets
+
+For experimentation with a future database-backed registry, sample SQL is included:
+
+- `migrations/001_provenance_and_rankings.sql` adds provenance fields and a providers table.
+- `queries/facet_filter.sql` demonstrates filtering APIs with facets.

--- a/apibotpi/__init__.py
+++ b/apibotpi/__init__.py
@@ -3,4 +3,4 @@
 from .registry import load_apis, search_apis
 
 __all__ = ["load_apis", "search_apis"]
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/apibotpi/__init__.py
+++ b/apibotpi/__init__.py
@@ -3,4 +3,4 @@
 from .registry import load_apis, search_apis
 
 __all__ = ["load_apis", "search_apis"]
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/apibotpi/__init__.py
+++ b/apibotpi/__init__.py
@@ -1,0 +1,6 @@
+"""API-BOTPI package."""
+
+from .registry import load_apis, search_apis
+
+__all__ = ["load_apis", "search_apis"]
+__version__ = "0.1.3"

--- a/apibotpi/apis.json
+++ b/apibotpi/apis.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Cat Facts",
+    "description": "Random cat trivia",
+    "quota": "unlimited",
+    "public_domain": true,
+    "url": "https://catfact.ninja/fact"
+  },
+  {
+    "name": "OpenWeather",
+    "description": "Weather data API",
+    "quota": "60 calls/minute",
+    "public_domain": false,
+    "url": "https://api.openweathermap.org/data/2.5/weather?q=London&appid=demo"
+  },
+  {
+    "name": "SpaceX",
+    "description": "SpaceX launch data",
+    "quota": "free",
+    "public_domain": true,
+    "url": "https://api.spacexdata.com/v4/launches/latest"
+  }
+]

--- a/apibotpi/beginner.py
+++ b/apibotpi/beginner.py
@@ -1,0 +1,34 @@
+"""Beginner-oriented CLI helpers."""
+
+from __future__ import annotations
+
+import click
+from tabulate import tabulate
+
+from .registry import search_apis
+
+
+@click.group()
+def main() -> None:
+    """Beginner commands for exploring APIs."""
+
+
+@main.command("list")
+@click.option("--free", is_flag=True, help="Only show free-tier APIs")
+@click.option("--test-mode", is_flag=True, help="Only APIs usable without keys")
+def list_beginner(free: bool, test_mode: bool) -> None:
+    """List beginner-friendly APIs with optional filters."""
+    quota = "free" if free else None
+    public = True if test_mode else None
+    rows = [
+        (api["name"], api.get("url", ""))
+        for api in search_apis(quota=quota, public=public)
+    ]
+    if rows:
+        print(tabulate(rows, headers=["API", "URL"]))
+    else:
+        print("No APIs found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/apibotpi/call.py
+++ b/apibotpi/call.py
@@ -1,0 +1,35 @@
+"""Fetch data from an API in the registry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.request
+
+from .registry import load_apis
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Call an API by name")
+    parser.add_argument("name", help="name of the API to call")
+    args = parser.parse_args()
+
+    for api in load_apis():
+        if api["name"].lower() == args.name.lower():
+            url = api.get("url")
+            if not url:
+                print("No URL configured for this API.")
+                return
+            with urllib.request.urlopen(url) as resp:
+                data = resp.read().decode("utf-8")
+            try:
+                parsed = json.loads(data)
+                print(json.dumps(parsed, indent=2))
+            except json.JSONDecodeError:
+                print(data)
+            return
+    print("API not found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/apibotpi/call.py
+++ b/apibotpi/call.py
@@ -1,11 +1,13 @@
-"""Fetch data from an API in the registry."""
+"""Fetch data from an API in the registry with safety guards."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import random
+import sys
 import time
+from urllib.parse import urlparse
 
 import requests
 
@@ -13,42 +15,62 @@ from .registry import load_apis
 
 
 def safe_request(fn):
+    """Retry helper with exponential backoff."""
+
     def wrapper(*a, **k):
+        timeout = k.pop("timeout", 15)
         last_exc = None
         for attempt in range(5):
             try:
-                return fn(*a, timeout=15, **k)
+                return fn(*a, timeout=timeout, **k)
             except requests.exceptions.RequestException as exc:
                 last_exc = exc
                 time.sleep(min(2 ** attempt + random.random(), 30))
         if last_exc:
             raise last_exc
+
     return wrapper
 
 
 @safe_request
-def fetch(url: str, **kwargs) -> requests.Response:
+def _get(url: str, **kwargs) -> requests.Response:
     return requests.get(url, **kwargs)
 
 
+def _print(obj: object) -> None:
+    print(json.dumps(obj, indent=2, ensure_ascii=False))
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Call an API by name")
-    parser.add_argument("name", help="name of the API to call")
-    args = parser.parse_args()
+    p = argparse.ArgumentParser(description="Call an API by name")
+    p.add_argument("name")
+    p.add_argument("--timeout", type=float, default=20.0)
+    p.add_argument("--header", action="append", default=[], help="k:v")
+    p.add_argument("--param", action="append", default=[], help="k=v")
+    args = p.parse_args()
+
+    headers = dict(h.split(":", 1) for h in args.header) if args.header else {}
+    params = dict(p.split("=", 1) for p in args.param) if args.param else {}
 
     for api in load_apis():
         if api["name"].lower() == args.name.lower():
-            url = api.get("url")
+            url = api.get("url") or api.get("base_url")
             if not url:
-                print("No URL configured for this API.")
+                print("No URL configured.")
                 return
-            resp = fetch(url)
-            data = resp.text
+            if urlparse(url).scheme != "https":
+                print("Refusing insecure HTTP URL. Use HTTPS.")
+                return
             try:
-                parsed = json.loads(data)
-                print(json.dumps(parsed, indent=2))
-            except json.JSONDecodeError:
-                print(data)
+                r = _get(url, headers=headers, params=params, timeout=args.timeout)
+                r.raise_for_status()
+                try:
+                    _print(r.json())
+                except Exception:
+                    print(r.text[:10000])
+            except requests.exceptions.RequestException as e:
+                print(f"Request failed: {e}", file=sys.stderr)
+                sys.exit(2)
             return
     print("API not found.")
 

--- a/apibotpi/install_api.py
+++ b/apibotpi/install_api.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
+from typing import Tuple
 import urllib.request
 from urllib.parse import urlparse
+import hashlib
 
 import click
 
@@ -33,7 +36,7 @@ def load_spec(source: str) -> dict:
         return yaml.safe_load(text)  # type: ignore[no-any-return]
 
 
-def normalize_spec(spec: dict) -> dict:
+def normalize_spec(spec: dict, source: str) -> dict:
     """Extract a minimal record from a spec."""
     name = spec.get("info", {}).get("title") or spec.get("name", "Unknown")
     servers = spec.get("servers") or []
@@ -46,22 +49,46 @@ def normalize_spec(spec: dict) -> dict:
             base_url = first
     host = urlparse(base_url).netloc
     public = bool(spec.get("public_domain"))
-    return {"name": name, "base_url": base_url, "host": host, "public_domain": public}
+    record = {
+        "name": name,
+        "base_url": base_url,
+        "host": host,
+        "public_domain": public,
+        "spec_hash": hashlib.sha256(
+            json.dumps(spec, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        ).hexdigest(),
+    }
+    if source.startswith(("http://", "https://")):
+        record["spec_url"] = source
+    return record
+
+
+REQUIRED = ("name", "host")
+
+
+def validate_record(rec: dict) -> Tuple[bool, list]:
+    missing = [k for k in REQUIRED if not rec.get(k)]
+    return (len(missing) == 0, missing)
 
 
 def upsert_api(record: dict, path: str = REGISTRY_PATH) -> int:
     """Insert or update an API record in the registry."""
+    ok, missing = validate_record(record)
+    if not ok:
+        raise ValueError(f"Record missing fields: {missing}")
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
     for idx, api in enumerate(data):
-        if api.get("name") == record["name"] and api.get("host") == record["host"]:
+        if str(api.get("name", "")).strip().lower() == str(record["name"]).strip().lower() and str(api.get("host", "")).lower() == str(record["host"]).lower():
             api.update(record)
             break
     else:
         data.append(record)
         idx = len(data) - 1
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), prefix=".apis.", suffix=".tmp")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, path)
     return idx
 
 
@@ -70,7 +97,7 @@ def upsert_api(record: dict, path: str = REGISTRY_PATH) -> int:
 def main(source: str) -> None:
     """Install API from OpenAPI/Postman/JSON."""
     spec = load_spec(source)
-    record = normalize_spec(spec)
+    record = normalize_spec(spec, source)
     api_id = upsert_api(record)
     click.echo(f"✅ Installed {record['name']} (id={api_id})")
 

--- a/apibotpi/install_api.py
+++ b/apibotpi/install_api.py
@@ -1,0 +1,79 @@
+"""CLI for installing API specs into the registry."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from urllib.parse import urlparse
+
+import click
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+REGISTRY_PATH = os.path.join(os.path.dirname(__file__), "apis.json")
+
+
+def load_spec(source: str) -> dict:
+    """Load a spec from a URL or local file."""
+    if source.startswith(("http://", "https://")):
+        with urllib.request.urlopen(source) as resp:  # type: ignore[arg-type]
+            text = resp.read().decode("utf-8")
+    else:
+        with open(source, "r", encoding="utf-8") as f:
+            text = f.read()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        if not yaml:
+            raise
+        return yaml.safe_load(text)  # type: ignore[no-any-return]
+
+
+def normalize_spec(spec: dict) -> dict:
+    """Extract a minimal record from a spec."""
+    name = spec.get("info", {}).get("title") or spec.get("name", "Unknown")
+    servers = spec.get("servers") or []
+    base_url = ""
+    if servers:
+        first = servers[0]
+        if isinstance(first, dict):
+            base_url = first.get("url", "")
+        elif isinstance(first, str):
+            base_url = first
+    host = urlparse(base_url).netloc
+    public = bool(spec.get("public_domain"))
+    return {"name": name, "base_url": base_url, "host": host, "public_domain": public}
+
+
+def upsert_api(record: dict, path: str = REGISTRY_PATH) -> int:
+    """Insert or update an API record in the registry."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    for idx, api in enumerate(data):
+        if api.get("name") == record["name"] and api.get("host") == record["host"]:
+            api.update(record)
+            break
+    else:
+        data.append(record)
+        idx = len(data) - 1
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    return idx
+
+
+@click.command()
+@click.argument("source")
+def main(source: str) -> None:
+    """Install API from OpenAPI/Postman/JSON."""
+    spec = load_spec(source)
+    record = normalize_spec(spec)
+    api_id = upsert_api(record)
+    click.echo(f"✅ Installed {record['name']} (id={api_id})")
+
+
+if __name__ == "__main__":
+    main()

--- a/apibotpi/registry.py
+++ b/apibotpi/registry.py
@@ -1,0 +1,33 @@
+"""Simple API registry with search helpers."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Iterable, Optional, Dict, Any
+
+
+def load_apis() -> Iterable[Dict[str, Any]]:
+    """Return all APIs from the bundled registry."""
+    with resources.files(__package__).joinpath("apis.json").open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def search_apis(*, quota: Optional[str] = None, public: Optional[bool] = None) -> Iterable[Dict[str, Any]]:
+    """Search the API registry.
+
+    Parameters
+    ----------
+    quota:
+        Substring to match within the quota description.
+    public:
+        If ``True``, only return APIs in the public domain. ``False`` returns
+        only non-public APIs. ``None`` disables the filter.
+    """
+    apis = load_apis()
+    for api in apis:
+        if quota and quota.lower() not in api["quota"].lower():
+            continue
+        if public is not None and api["public_domain"] != public:
+            continue
+        yield api

--- a/apibotpi/search.py
+++ b/apibotpi/search.py
@@ -3,8 +3,21 @@
 from __future__ import annotations
 
 import argparse
+import csv
+import json
+import sys
+from typing import List
 
 from .registry import search_apis
+
+
+def _print_table(results: List[dict]) -> None:
+    for api in results:
+        url = api.get("url", "")
+        extra = f" - {url}" if url else ""
+        print(
+            f"{api['name']}: {api['description']} (quota: {api['quota']}){extra}"
+        )
 
 
 def main() -> None:
@@ -21,34 +34,64 @@ def main() -> None:
         action="store_true",
         help="prompt for filters interactively",
     )
+    parser.add_argument(
+        "--no-auth",
+        action="store_true",
+        help="prefer no-auth/public APIs",
+    )
+    parser.add_argument("--json", action="store_true", help="output JSON")
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "csv", "xlsx"],
+        default="table",
+        help="output format",
+    )
     args = parser.parse_args()
 
     quota = args.quota
     public = args.public
     if args.wizard:
-        quota = input("Filter by quota substring (leave blank for any): ") or None
-        public_choice = (
-            input("Only public domain APIs? [y/n/blank for any]: ")
-            .strip()
-            .lower()
-        )
-        if public_choice == "y":
-            public = True
-        elif public_choice == "n":
-            public = False
+        print("What do you want to do?")
+        print("  1) Learn APIs  2) Weather  3) Countries  4) Space  5) Health info")
+        choice = (input("Choose [1-5]: ").strip() or "1")
+        if choice == "2":
+            quota, public = None, True
+        elif choice == "3":
+            quota, public = None, True
+        elif choice == "4":
+            quota, public = "free", True
+        elif choice == "5":
+            quota, public = "free", True
         else:
+            quota = None
             public = None
+    if args.no_auth:
+        public = True
+
+    out_format = "json" if args.json else args.format
 
     results = list(search_apis(quota=quota, public=public))
     if not results:
         print("No APIs found.")
         return
-    for api in results:
-        url = api.get("url", "")
-        extra = f" - {url}" if url else ""
-        print(
-            f"{api['name']}: {api['description']} (quota: {api['quota']}){extra}"
-        )
+
+    if out_format == "json":
+        print(json.dumps(results, indent=2, ensure_ascii=False))
+    elif out_format == "csv":
+        writer = csv.DictWriter(sys.stdout, fieldnames=results[0].keys())
+        writer.writeheader()
+        writer.writerows(results)
+    elif out_format == "xlsx":
+        try:
+            import pandas as pd  # type: ignore
+
+            df = pd.DataFrame(results)
+            df.to_excel("apis.xlsx", index=False)
+            print("Wrote apis.xlsx")
+        except Exception as exc:  # pragma: no cover - optional dependency
+            print(f"xlsx export requires pandas and openpyxl ({exc})")
+    else:
+        _print_table(results)
 
 
 if __name__ == "__main__":

--- a/apibotpi/search.py
+++ b/apibotpi/search.py
@@ -1,0 +1,55 @@
+"""Command-line helpers for searching the API registry."""
+
+from __future__ import annotations
+
+import argparse
+
+from .registry import search_apis
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Search available APIs")
+    parser.add_argument("--quota", help="substring to match within the quota description")
+    parser.add_argument(
+        "--public",
+        action="store_true",
+        default=None,
+        help="only show APIs in the public domain",
+    )
+    parser.add_argument(
+        "--wizard",
+        action="store_true",
+        help="prompt for filters interactively",
+    )
+    args = parser.parse_args()
+
+    quota = args.quota
+    public = args.public
+    if args.wizard:
+        quota = input("Filter by quota substring (leave blank for any): ") or None
+        public_choice = (
+            input("Only public domain APIs? [y/n/blank for any]: ")
+            .strip()
+            .lower()
+        )
+        if public_choice == "y":
+            public = True
+        elif public_choice == "n":
+            public = False
+        else:
+            public = None
+
+    results = list(search_apis(quota=quota, public=public))
+    if not results:
+        print("No APIs found.")
+        return
+    for api in results:
+        url = api.get("url", "")
+        extra = f" - {url}" if url else ""
+        print(
+            f"{api['name']}: {api['description']} (quota: {api['quota']}){extra}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Set up a virtual environment and install API-BOTPI.
+set -e
+python3 -m venv .venv                # create virtual environment
+source .venv/bin/activate            # activate it
+pip install --upgrade pip            # ensure pip is up to date
+pip install .                        # install package
+echo "Installation complete. Activate the environment with 'source .venv/bin/activate'"

--- a/migrations/001_provenance_and_rankings.sql
+++ b/migrations/001_provenance_and_rankings.sql
@@ -1,0 +1,8 @@
+-- Migration for provenance & rankings
+ALTER TABLE apis ADD COLUMN spec_url TEXT;
+ALTER TABLE apis ADD COLUMN spec_hash TEXT;
+ALTER TABLE apis ADD COLUMN quality_score REAL DEFAULT 0;
+CREATE TABLE IF NOT EXISTS providers (
+  id INTEGER PRIMARY KEY, name TEXT UNIQUE, website TEXT, status_page_url TEXT
+);
+ALTER TABLE apis ADD COLUMN provider_id INTEGER REFERENCES providers(id);

--- a/migrations/002_beginner_metadata.sql
+++ b/migrations/002_beginner_metadata.sql
@@ -1,0 +1,15 @@
+ALTER TABLE apis ADD COLUMN onboarding_score REAL;
+ALTER TABLE apis ADD COLUMN learn_time_minutes INTEGER;
+ALTER TABLE apis ADD COLUMN sandbox_url TEXT;
+ALTER TABLE apis ADD COLUMN quickstart_url TEXT;
+ALTER TABLE apis ADD COLUMN dangerous BOOLEAN DEFAULT 0;
+ALTER TABLE apis ADD COLUMN mock_supported BOOLEAN DEFAULT 0;
+ALTER TABLE apis ADD COLUMN approval_sla_days INTEGER;
+ALTER TABLE apis ADD COLUMN tutorial_quality_score REAL;
+ALTER TABLE apis ADD COLUMN examples_count INTEGER;
+ALTER TABLE apis ADD COLUMN endpoints_count INTEGER;
+ALTER TABLE apis ADD COLUMN has_postman BOOLEAN DEFAULT 0;
+ALTER TABLE apis ADD COLUMN has_sdk BOOLEAN DEFAULT 0;
+ALTER TABLE apis ADD COLUMN error_model_quality TEXT;
+ALTER TABLE apis ADD COLUMN auth_complexity TEXT;
+ALTER TABLE apis ADD COLUMN first_success_rate REAL;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "api-botpi"
-version = "0.1.4"
+version = "0.1.5"
 description = "Minimal API-BOTPI package"
 authors = [{name = "API-BOTPI", email = "example@example.com"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,19 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "api-botpi"
-version = "0.1.3"
+version = "0.1.4"
 description = "Minimal API-BOTPI package"
 authors = [{name = "API-BOTPI", email = "example@example.com"}]
 readme = "README.md"
 requires-python = ">=3.8"
 license = {file = "LICENSE"}
-dependencies = ["click", "PyYAML"]
+dependencies = ["click", "PyYAML", "requests", "tabulate"]
 
 [project.scripts]
 api-search = "apibotpi.search:main"
 api-call = "apibotpi.call:main"
 install-api = "apibotpi.install_api:main"
+api-beginner = "apibotpi.beginner:main"
 
 [tool.setuptools.package-data]
 apibotpi = ["apis.json"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "api-botpi"
+version = "0.1.3"
+description = "Minimal API-BOTPI package"
+authors = [{name = "API-BOTPI", email = "example@example.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+dependencies = ["click", "PyYAML"]
+
+[project.scripts]
+api-search = "apibotpi.search:main"
+api-call = "apibotpi.call:main"
+install-api = "apibotpi.install_api:main"
+
+[tool.setuptools.package-data]
+apibotpi = ["apis.json"]
+
+[tool.setuptools.packages.find]
+include = ["apibotpi"]

--- a/queries/facet_filter.sql
+++ b/queries/facet_filter.sql
@@ -1,0 +1,6 @@
+SELECT * FROM apis
+WHERE (:cat IS NULL OR category = :cat)
+AND (:auth IS NULL OR auth_type LIKE :auth)
+AND (:free IS NULL OR pricing LIKE '%free%')
+ORDER BY quality_score DESC, name ASC
+LIMIT :limit OFFSET :offset;


### PR DESCRIPTION
## Summary
- add install-api command to ingest API specs into the registry
- register new CLI with dependencies and package data
- document install-api and include SQL samples for migrations and facet filters

## Testing
- `./install.sh`
- `install-api demo_spec.json`
- `api-search --public`


------
https://chatgpt.com/codex/tasks/task_e_68b7664c3a50832ebbdc3acb919f43ad